### PR TITLE
merge Survey Design + Caveats into one section, text and spacing tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ drive_url_map_dryrun.json
 
 # Editor backups
 *~
+
+# Local session notes / planning (never commit)
+sessions/
+lukeplanning.txt

--- a/css/styles.css
+++ b/css/styles.css
@@ -207,7 +207,12 @@ body {
 }
 
 .statement:first-of-type {
-  margin-top: 0;
+  margin-top: -1rem;
+}
+
+/* Tighten the gap between the intro statements and the first card group */
+.statement + .card-group {
+  margin-top: 1.75rem;
 }
 
 
@@ -223,6 +228,22 @@ body {
 .split img {
   width: 100%;
   border-radius: 12px;
+}
+
+/* Tighter split spacing when nested inside a boxed section */
+.citation .split {
+  margin: 2rem auto 2.5rem;
+}
+
+.split-figure {
+  margin: 0;
+}
+
+.split-figure figcaption {
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.4;
 }
 
 @media (max-width: 900px) {

--- a/index.html
+++ b/index.html
@@ -48,9 +48,7 @@
 </section> -->
 
   <p class="statement">
-    The Arecibo Legacy Fast ALFA (ALFALFA) Survey was a state-of-the-art 21 cm
-    neutral hydrogen survey that observed approximately a sixth of the sky with the former Arecibo radio telescope and detected
-    more than 30,000 extragalactic sources.
+    The Arecibo Legacy Fast ALFA (ALFALFA) Survey was a wide-field blind 21 cm neutral hydrogen survey.
   </p>
 
   <p class="statement">
@@ -60,7 +58,7 @@
   <div class="card-group">
     <h2 class="group-title">Using ALFALFA</h2>
     <p class="group-desc">
-      The ALFALFA Survey produced a rich set of data products, including catalogs of over 30,000 extragalactic sources and data cubes covering the non-galactic sky visible to Arecibo to cz~17,000 km/s. Users are strongly advised to consult the caveats before downloading or using the data.
+      The ALFALFA Survey produced a rich set of data products as described at the links below. Users are strongly advised to consult the caveats before using the data.
     </p>
 
     <section class="cards">
@@ -69,7 +67,7 @@
         <p> Catalogs, grids, spectra, and other data products.</p>
       </a>
 
-      <a class="card" href="#design">
+      <a class="card" href="#caveats">
         <h2>Survey Design & Caveats</h2>
         <p> Design, caveats, and recommendations for future surveys. </p>
       </a>
@@ -84,7 +82,7 @@
   <div class="card-group">
     <h2 class="group-title">Learning about ALFALFA</h2>
     <p class="group-desc">
-      The ALFALFA Survey was transformational to our understanding of extragalactic HI in the local universe. The links below summarize the scientific legacy of ALFALFA, as well as it's pioneering educational model that involved hundreds of undergraduate students and faculty from small colleges and universities.
+      The ALFALFA Survey transformed our understanding of extragalactic HI in the local universe. The links below summarize the scientific and educational legacy of ALFALFA.
     </p>
 
     <section class="cards">
@@ -104,50 +102,6 @@
       </a>
     </section>
   </div>
-
-<section id="caveats" class="citation">
-  <h2>Important Caveats for Using ALFALFA Data</h2>
-
-  <details class="caveat">
-    <summary>The beam is big</summary>
-    <div class="caveat-body">
-      <p>The ALFA beam was large (~3.3′ × 3.8′) with significant side lobes, so nearby sources at similar velocities can blend into a detection and extended sources are hard to extract cleanly. Positions are still reliable for high signal-to-noise detections, and published manually assigned optical-counterpart coordinates are recommended for most uses.</p>
-      <p><a href="caveats.html#beam">More details...</a></p>
-    </div>
-  </details>
-
-  <details class="caveat">
-    <summary>Bandwidth matters</summary>
-    <div class="caveat-body">
-      <p>ALFALFA only covered 1335–1435 MHz, so it cannot detect HI beyond ~18,000 km/s (~260 Mpc), and radio frequency interference removes parts of that range. Velocities above 15,000 km/s are strongly affected and should not be used for statistical studies.</p>
-      <p><a href="caveats.html#bandwidth">More details...</a></p>
-    </div>
-  </details>
-
-  <details class="caveat">
-    <summary>Completeness and statistics</summary>
-    <div class="caveat-body">
-      <p>Completeness depends on both a source's integrated flux and its velocity width, so narrow-profile (e.g. face-on) galaxies are easier to detect than broad-profile ones. For statistical work, use only the high-S/N Code 1 sources and their completeness limit, not the redshift-confirmed Code 2s.</p>
-      <p><a href="caveats.html#completeness">More details...</a></p>
-    </div>
-  </details>
-
-  <details class="caveat">
-    <summary>Velocity widths</summary>
-    <div class="caveat-body">
-      <p>The catalog's W50 velocity widths are robust and corrected for instrumental broadening, but carry no inclination correction and are limited by the ~10–11 km/s spectral resolution. Converting them to other kinematic measures such as flat rotation speed requires care and external calibrations.</p>
-      <p><a href="caveats.html#velocity-widths">More details...</a></p>
-    </div>
-  </details>
-
-  <details class="caveat">
-    <summary>A survey of two halves</summary>
-    <div class="caveat-body">
-      <p>ALFALFA covers two very different regions: the Virgo-dominated “spring” sky and the “fall” sky containing the Local Void. They also had unequal optical redshift coverage, so some low-S/N sources catalogued in the spring sky would have been excluded in the fall sky.</p>
-      <p><a href="caveats.html#two-halves">More details...</a></p>
-    </div>
-  </details>
-</section>
 
 <section id="science" class="citation">
 <h2> Major Scientific Achievements of the ALFALFA HI Survey </h2>
@@ -241,17 +195,64 @@ The survey led to over a <a href="https://scixplorer.org/public-libraries/3ZQifd
 
 </section>
 
-<section id="design" class="citation">
-<div class="split">
-  <div>
-    <h2>Survey Design and Details</h2>
-    <p>
-      ALFALFA was a blind 21 cm HI spectral-line survey carried out with the Arecibo telescope between 2005 and 2012, using nearly 5000 hours of time and a two-pass drift-scan technique with the seven-horn ALFA receiver. It mapped roughly 7000 square degrees of high-Galactic-latitude sky (about a fifth of the sky) over a 1345–1435 MHz bandpass, reaching recessional velocities up to ~17,500 km/s (D ~ 250 Mpc) at ~4 arcmin resolution and 2–4 mJy/beam sensitivity.
-    </p>
-    <p><a href="surveydesign.html">Read more about the survey design →</a></p>
+<section id="caveats" class="citation">
+  <h2>Survey Design and Caveats</h2>
+  <p>This section contains important caveats about using ALFALFA data, and more detail about the survey and its design. Full details are given on the <a href="caveats.html">caveats</a> and <a href="surveydesign.html">survey design</a> pages.</p>
+
+  <div class="split">
+    <div>
+      <p>
+        ALFALFA was a blind 21 cm HI spectral-line survey carried out with the Arecibo telescope between 2005 and 2012, using nearly 5000 hours of time and a two-pass drift-scan technique with the seven-horn ALFA receiver. It mapped roughly 7000 square degrees of high-Galactic-latitude sky (about a fifth of the sky) over a 1345–1435 MHz bandpass, reaching recessional velocities up to ~17,500 km/s (D ~ 250 Mpc) at ~4 arcmin resolution and 2–4 mJy/beam sensitivity.
+      </p>
+      <p><a href="surveydesign.html">Read more about the survey design →</a></p>
+    </div>
+    <figure class="split-figure">
+      <img src="haynes2018_fig1.jpg" alt="Final source distribution of the ALFALFA survey (Haynes et al. 2018), spring and fall sky.">
+      <figcaption>The ALFALFA source distribution across the northern hemisphere spring (top) and fall (bottom) sky (Haynes et al. 2018).</figcaption>
+    </figure>
   </div>
-  <img src="survey_footprint.png" alt="Survey footprint">
-</div>
+
+  <h3>Important Caveats for Using ALFALFA Data:</h3>
+
+  <details class="caveat">
+    <summary>The beam is big</summary>
+    <div class="caveat-body">
+      <p>The ALFA beam was large (~3.3′ × 3.8′) with significant side lobes, so nearby sources at similar velocities can blend into a detection and extended sources are hard to extract cleanly. Positions are still reliable for high signal-to-noise detections, and published manually assigned optical-counterpart coordinates are recommended for most uses.</p>
+      <p><a href="caveats.html#beam">More details...</a></p>
+    </div>
+  </details>
+
+  <details class="caveat">
+    <summary>Bandwidth matters</summary>
+    <div class="caveat-body">
+      <p>ALFALFA only covered 1335–1435 MHz, so it cannot detect HI beyond ~18,000 km/s (~260 Mpc), and radio frequency interference removes parts of that range. Velocities above 15,000 km/s are strongly affected and should not be used for statistical studies.</p>
+      <p><a href="caveats.html#bandwidth">More details...</a></p>
+    </div>
+  </details>
+
+  <details class="caveat">
+    <summary>Completeness and statistics</summary>
+    <div class="caveat-body">
+      <p>Completeness depends on both a source's integrated flux and its velocity width, so narrow-profile (e.g. face-on) galaxies are easier to detect than broad-profile ones. For statistical work, use only the high-S/N Code 1 sources and their completeness limit, not the redshift-confirmed Code 2s.</p>
+      <p><a href="caveats.html#completeness">More details...</a></p>
+    </div>
+  </details>
+
+  <details class="caveat">
+    <summary>Velocity widths</summary>
+    <div class="caveat-body">
+      <p>The catalog's W50 velocity widths are robust and corrected for instrumental broadening, but carry no inclination correction and are limited by the ~10–11 km/s spectral resolution. Converting them to other kinematic measures such as flat rotation speed requires care and external calibrations.</p>
+      <p><a href="caveats.html#velocity-widths">More details...</a></p>
+    </div>
+  </details>
+
+  <details class="caveat">
+    <summary>A survey of two halves</summary>
+    <div class="caveat-body">
+      <p>ALFALFA covers two very different regions: the Virgo-dominated “spring” sky and the “fall” sky containing the Local Void. They also had unequal optical redshift coverage, so some low-S/N sources catalogued in the spring sky would have been excluded in the fall sky.</p>
+      <p><a href="caveats.html#two-halves">More details...</a></p>
+    </div>
+  </details>
 </section>
 
 


### PR DESCRIPTION
- Combine caveats and survey design into a single 'Survey Design and Caveats' section (with intro note linking caveats.html/surveydesign.html and 'Important Caveats...' subheader above the dropdowns)
- Order: Science -> Survey Design and Caveats -> Archives
- Reword intro statement and the two card-group descriptions
- Survey figure now uses haynes2018_fig1.jpg with a caption (the old survey_footprint.png did not exist)
- Tighten statement spacing; ignore sessions/ and lukeplanning.txt