### PR TITLE
Science results as dropdowns, sticky top nav, education note width

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,22 +14,23 @@
 
 <body class="no-banner">
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-       <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+     <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/caveats.html
+++ b/caveats.html
@@ -15,22 +15,23 @@
 
 <body>
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-        <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+      <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/code.html
+++ b/code.html
@@ -15,22 +15,23 @@
 
 <body>
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-       <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+     <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/css/styles.css
+++ b/css/styles.css
@@ -68,12 +68,23 @@ body {
   background: white;
 }
 
+/* The nav is a direct child of <body> (not nested inside .site-header) so that
+   its sticky containing block is the whole document -- that is what keeps it
+   pinned for the entire scroll rather than only for the height of the banner. */
 .top-nav {
   background: white;
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 100;
+}
+
+/* Height reserved for the pinned nav when jumping to an in-page anchor
+   (#science, #archive, #caveats, ...), so the target heading lands below the
+   nav bar instead of underneath it. Roughly .nav-inner's height: the 0.85rem
+   links plus its 0.75rem top and bottom padding, with a little breathing room. */
+[id] {
+  scroll-margin-top: 4rem;
 }
 
 .nav-inner {

--- a/data.html
+++ b/data.html
@@ -14,22 +14,23 @@
 
 <!--<body class="no-banner">-->
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-       <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+     <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/education.html
+++ b/education.html
@@ -14,22 +14,23 @@
 
 <!--<body class="no-banner">-->
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-       <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+     <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/education.html
+++ b/education.html
@@ -109,10 +109,11 @@
       </li>
     </ul>
   </section>
+
+  <p> Note: the UAT has also maintained a google site for team members, that may be cleaned up and made public at a later date.
+    Team members can access the google site <a href="https://sites.google.com/union.edu/uatapps/overview">here</a>. </p>
 </main>
 
-<p> Note: the UAT has also maintained a google site for team members, that may be cleaned up and made public at a later date. 
-  Team members can access the google site <a href="https://sites.google.com/union.edu/uatapps/overview">here</a>. </p>  
 <footer>
   <div class="footer-inner">
     © ALFALFA Survey Legacy • Arecibo Observatory (1963–2020)

--- a/index.html
+++ b/index.html
@@ -129,62 +129,97 @@ This produced a rich dataset used in studies of galaxy evolution, cosmology, and
 
 <p>A few of the survey's key findings are discussed below.</p>
 
-<h3>1. First Comprehensive Census of HI-Bearing Galaxies</h3>
-<p>
-ALFALFA detected HI emission in more than <a href="https://scixplorer.org/abs/2018ApJ...861...49H/abstract">31,000 galaxies</a>, making it the largest blind HI survey of its kind in the local Universe (at the time of its completion). 
-The survey provided the first comprehensive census of gas-rich galaxies out to roughly 800 million light-years (250 Mpc), over about one-sixth of the sky. 
-Its large volume enabled meaningful sampling of cosmic structure across a cosmologically significant region of space.
-</p>
+<!-- Each key science result is a click-to-expand dropdown, reusing the same
+     .caveat / .caveat-body styling as the Survey Design and Caveats section. -->
 
-<h3>2. HI Mass Function and Cosmic Gas Density</h3>
-<p>
-One of ALFALFA’s flagship scientific results was a precise measurement of the <a href="https://scixplorer.org/abs/2010ApJ...723.1359M/abstract"><strong>HI Mass Function (HIMF)</strong></a>, 
-the <a href="https://scixplorer.org/abs/2018MNRAS.477....2J/abstract">abundance of galaxies</a> as a function of their neutral hydrogen mass. 
-Integrating this function yielded an improved estimate of the cosmic HI mass density (Ω<sub>HI</sub>), 
-a key anchor point for models of galaxy formation and evolution. The complementary <a href="https://ui.adsabs.harvard.edu/abs/2011ApJ...739...38P/abstract">velocity width function</a> also highlighted the tensions between observed galaxy population and predictions from cold dark matter cosmology, particularly at low masses.
-</p>
+<details class="caveat">
+  <summary>1. First Comprehensive Census of HI-Bearing Galaxies</summary>
+  <div class="caveat-body">
+    <p>
+    ALFALFA detected HI emission in more than <a href="https://scixplorer.org/abs/2018ApJ...861...49H/abstract">31,000 galaxies</a>, making it the largest blind HI survey of its kind in the local Universe (at the time of its completion).
+    The survey provided the first comprehensive census of gas-rich galaxies out to roughly 800 million light-years (250 Mpc), over about one-sixth of the sky.
+    Its large volume enabled meaningful sampling of cosmic structure across a cosmologically significant region of space.
+    </p>
+  </div>
+</details>
 
-<h3>3. Discovery of Unusual and Exotic HI-Rich Systems</h3>
-<p>
-ALFALFA revealed rare and unexpected types of galaxies often missed in optical surveys because of their faint stellar components. 
-These include gas-rich dwarf galaxies, very <a href="https://scixplorer.org/abs/2021AJ....162..274L/abstract">low surface brightness systems</a>, and HI-bearing ultra-diffuse galaxies (HUDs) 
-with large gas reservoirs but little stellar mass. 
-The survey also identified extremely low-metallicity systems such as <a href="https://scixplorer.org/abs/2013AJ....146...15G/abstract">Leo P</a>, 
-providing insight into chemically primitive galaxy environments.
-</p>
+<details class="caveat">
+  <summary>2. HI Mass Function and Cosmic Gas Density</summary>
+  <div class="caveat-body">
+    <p>
+    One of ALFALFA’s flagship scientific results was a precise measurement of the <a href="https://scixplorer.org/abs/2010ApJ...723.1359M/abstract"><strong>HI Mass Function (HIMF)</strong></a>,
+    the <a href="https://scixplorer.org/abs/2018MNRAS.477....2J/abstract">abundance of galaxies</a> as a function of their neutral hydrogen mass.
+    Integrating this function yielded an improved estimate of the cosmic HI mass density (Ω<sub>HI</sub>),
+    a key anchor point for models of galaxy formation and evolution. The complementary <a href="https://ui.adsabs.harvard.edu/abs/2011ApJ...739...38P/abstract">velocity width function</a> also highlighted the tensions between observed galaxy population and predictions from cold dark matter cosmology, particularly at low masses.
+    </p>
+  </div>
+</details>
 
-<h3>4. Search for “Dark” Galaxies</h3>
-<p>
-A major motivation of ALFALFA was the search for gas-rich systems with few or no stars—so-called <a href="https://scixplorer.org/abs/2017ApJ...842..133L/abstract"><i>dark galaxies</i></a>. 
-While no purely starless galaxies were confirmed, the survey identified <a href="https://scixplorer.org/abs/2021AJ....162..274L/abstract">candidate systems</a> with much more gas than stars, 
-raising important questions about star formation inefficiency and the properties of low-mass dark matter halos.
-</p>
+<details class="caveat">
+  <summary>3. Discovery of Unusual and Exotic HI-Rich Systems</summary>
+  <div class="caveat-body">
+    <p>
+    ALFALFA revealed rare and unexpected types of galaxies often missed in optical surveys because of their faint stellar components.
+    These include gas-rich dwarf galaxies, very <a href="https://scixplorer.org/abs/2021AJ....162..274L/abstract">low surface brightness systems</a>, and HI-bearing ultra-diffuse galaxies (HUDs)
+    with large gas reservoirs but little stellar mass.
+    The survey also identified extremely low-metallicity systems such as <a href="https://scixplorer.org/abs/2013AJ....146...15G/abstract">Leo P</a>,
+    providing insight into chemically primitive galaxy environments.
+    </p>
+  </div>
+</details>
 
-<h3>5. Galaxy Evolution and Gas Scaling Relations</h3>
-<p>
-By combining ALFALFA HI data with optical and ultraviolet surveys such as SDSS and GALEX, 
-astronomers established detailed <a href="https://scixplorer.org/abs/2010MNRAS.403..683C/abstract">scaling relations</a> linking HI mass with stellar mass, star formation rate, and galaxy color. 
-The survey also provided important constraints on the baryonic Tully–Fisher relation, 
-which connects galaxy rotation dynamics to total baryonic mass, 
-highlighting the fundamental role of gas in regulating star formation.
-</p>
+<details class="caveat">
+  <summary>4. Search for “Dark” Galaxies</summary>
+  <div class="caveat-body">
+    <p>
+    A major motivation of ALFALFA was the search for gas-rich systems with few or no stars—so-called <a href="https://scixplorer.org/abs/2017ApJ...842..133L/abstract"><i>dark galaxies</i></a>.
+    While no purely starless galaxies were confirmed, the survey identified <a href="https://scixplorer.org/abs/2021AJ....162..274L/abstract">candidate systems</a> with much more gas than stars,
+    raising important questions about star formation inefficiency and the properties of low-mass dark matter halos.
+    </p>
+  </div>
+</details>
 
-<h3>6. Cosmological and Large-Scale Structure Insights</h3>
-<p>
-The large volume spanned by ALFALFA enabled the measurement of the <a href="https://scixplorer.org/abs/2013ApJ...776...43P/abstract">correlation function</a> of gas-rich galaxies, a measure of how galaxies cluster in space. This demonstrated that blue, gas-rich galaxies are much less clustered than the overall galaxy population, avoiding red galaxies on average, and favoring low-density environments instead.
-</p>
+<details class="caveat">
+  <summary>5. Galaxy Evolution and Gas Scaling Relations</summary>
+  <div class="caveat-body">
+    <p>
+    By combining ALFALFA HI data with optical and ultraviolet surveys such as SDSS and GALEX,
+    astronomers established detailed <a href="https://scixplorer.org/abs/2010MNRAS.403..683C/abstract">scaling relations</a> linking HI mass with stellar mass, star formation rate, and galaxy color.
+    The survey also provided important constraints on the baryonic Tully–Fisher relation,
+    which connects galaxy rotation dynamics to total baryonic mass,
+    highlighting the fundamental role of gas in regulating star formation.
+    </p>
+  </div>
+</details>
 
-<h3>7. Gas and Dark Matter Halo Connection</h3>
-<p>
-Through spectral line stacking, a technique that combines the spectra of many galaxies based on prior known positions and redshifts (from optical surveys), ALFALFA studied the gas content of <a href="https://scixplorer.org/abs/2011MNRAS.411..993F/abstract">elliptical galaxies</a> and galaxies hosting active galactic nuclei, which often have too little gas to be detected individually. Analyses of the stacked spectra of galaxy groups and satellites also produced a direct measurement of the HI mass--dark matter halo mass <a href="https://scixplorer.org/abs/2020ApJ...894...92G/abstract">relation</a>, a key constraint for galaxy formation models. 
-</p>
+<details class="caveat">
+  <summary>6. Cosmological and Large-Scale Structure Insights</summary>
+  <div class="caveat-body">
+    <p>
+    The large volume spanned by ALFALFA enabled the measurement of the <a href="https://scixplorer.org/abs/2013ApJ...776...43P/abstract">correlation function</a> of gas-rich galaxies, a measure of how galaxies cluster in space. This demonstrated that blue, gas-rich galaxies are much less clustered than the overall galaxy population, avoiding red galaxies on average, and favoring low-density environments instead.
+    </p>
+  </div>
+</details>
 
-<h3>8. Legacy Data and Community Impact</h3>
-<p>
-ALFALFA became a cornerstone dataset in extragalactic astronomy. 
-Its publicly released catalogs and spectra are widely used as benchmarks for next-generation HI surveys conducted with facilities such as ASKAP, MeerKAT, and the forthcoming Square Kilometre Array (SKA). 
-The survey led to over a <a href="https://scixplorer.org/public-libraries/3ZQifdHSRYeOYc6cm7btRQ">hundred scientific publications</a>, numerous graduate theses, and introduced hundreds of undergraduate students to research in astronomy through the Undergraduate ALFALFA Team (UAT) program.
-</p>
+<details class="caveat">
+  <summary>7. Gas and Dark Matter Halo Connection</summary>
+  <div class="caveat-body">
+    <p>
+    Through spectral line stacking, a technique that combines the spectra of many galaxies based on prior known positions and redshifts (from optical surveys), ALFALFA studied the gas content of <a href="https://scixplorer.org/abs/2011MNRAS.411..993F/abstract">elliptical galaxies</a> and galaxies hosting active galactic nuclei, which often have too little gas to be detected individually. Analyses of the stacked spectra of galaxy groups and satellites also produced a direct measurement of the HI mass--dark matter halo mass <a href="https://scixplorer.org/abs/2020ApJ...894...92G/abstract">relation</a>, a key constraint for galaxy formation models.
+    </p>
+  </div>
+</details>
+
+<details class="caveat">
+  <summary>8. Legacy Data and Community Impact</summary>
+  <div class="caveat-body">
+    <p>
+    ALFALFA became a cornerstone dataset in extragalactic astronomy.
+    Its publicly released catalogs and spectra are widely used as benchmarks for next-generation HI surveys conducted with facilities such as ASKAP, MeerKAT, and the forthcoming Square Kilometre Array (SKA).
+    The survey led to over a <a href="https://scixplorer.org/public-libraries/3ZQifdHSRYeOYc6cm7btRQ">hundred scientific publications</a>, numerous graduate theses, and introduced hundreds of undergraduate students to research in astronomy through the Undergraduate ALFALFA Team (UAT) program.
+    </p>
+  </div>
+</details>
 
 
 <h2>Further Reading</h2>

--- a/index.html
+++ b/index.html
@@ -15,22 +15,23 @@
 
 <body>
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-        <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+      <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/science.html
+++ b/science.html
@@ -15,22 +15,23 @@
 
 <body>
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-        <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+      <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">

--- a/surveydesign.html
+++ b/surveydesign.html
@@ -15,22 +15,23 @@
 
 <body>
 
-<header class="site-header">
-  <nav class="top-nav">
-    <div class="nav-inner">
-      <div class="site-title">
-        <a href=index.html>ALFALFA Legacy</a>
-      </div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="data.html">Data</a>
-        <a href="science.html">Science</a>
-        <a href="education.html">Education</a>
-        <a href="index.html#archive">Archives</a>
-      </div>
+<nav class="top-nav">
+  <div class="nav-inner">
+    <div class="site-title">
+      <a href=index.html>ALFALFA Legacy</a>
     </div>
-  </nav>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="data.html">Data</a>
+      <a href="science.html">Science</a>
+      <a href="education.html">Education</a>
+      <a href="index.html#archive">Archives</a>
+    </div>
+  </div>
+</nav>
+
+<header class="site-header">
 
   <div class="hero">
     <div class="hero-content">


### PR DESCRIPTION
Three small front-end changes. No wording changed anywhere.

**1. Science results as dropdowns** (`index.html`) — the eight numbered key
science results were one long block of text. Each is now a `<details>` dropdown,
reusing the existing `.caveat` styling so the section matches the Survey Design
and Caveats section below it. No CSS needed.

**2. Top nav stays pinned for the whole page** (8 base pages + `css/styles.css`)
— the nav already had `position: sticky`, but was nested inside
`<header class="site-header">`, which contains only the nav and the 260px hero.
Sticky only works within the parent's box, so the nav unstuck once the banner
scrolled past. Moving `<nav class="top-nav">` out to be a direct child of
`<body>` gives it the whole document as its sticky container. Sticky rule itself
unchanged. Also added `scroll-margin-top` on `[id]` so in-page anchors land
below the nav. `rwebhtml/` and `aweb/` are untouched.

**3. Education note width** (`education.html`) — the "Note: the UAT has also
maintained a google site..." paragraph sat outside `</main>`, so it missed
`.content`'s max-width and ran to the edge of the screen. Moved it inside
`<main>`.

Touches `science.html`, but only its header block, so it should not conflict
with the pending #28.
